### PR TITLE
Added the --update-dir param parsing and handling with argparse

### DIFF
--- a/scripts/theatre-cli
+++ b/scripts/theatre-cli
@@ -4,6 +4,25 @@ import os
 from theatre_cli.config import load_config, save_config
 from theatre_cli.movie import set_movie_dir, list_movies
 from theatre_cli.player import choose_player_and_play
+import argparse
+
+
+def update_movie_path(directory):
+    print(f'Updating movie directory to: {directory}')
+    config_data = load_config()  # Load our config
+    if not config_data:
+        print("ERR: Config not set")
+        return
+
+    config_data[0]['movie_dir'] = directory  #Modify our config
+    save_config(config_data) #Save it back down
+    return
+
+def is_valid_dir(directory):
+    if os.path.isdir(directory):
+        return directory
+    else:
+        raise argparse.ArgumentTypeError(f'{directory} is not a valid directory')
 
 def main():
     config_data = load_config()
@@ -26,6 +45,12 @@ def main():
             "movie_dir": movie_dir
         }]
         save_config(config_data)
+
+    parser = argparse.ArgumentParser(description='Theatre CLI')
+    parser.add_argument('--update-dir', metavar='PATH', type=is_valid_dir, help='the directory to set as movie path')
+    args = parser.parse_args()
+    if args.update_dir:
+        update_movie_path(args.update_dir)
 
     movie_dir = config_data[0]['movie_dir']
     choose_player_and_play(movie_dir)

--- a/scripts/theatre-cli
+++ b/scripts/theatre-cli
@@ -14,8 +14,8 @@ def update_movie_path(directory):
         print("ERR: Config not set")
         return
 
-    config_data[0]['movie_dir'] = directory  #Modify our config
-    save_config(config_data) #Save it back down
+    config_data[0]['movie_dir'] = directory  # Modify our config
+    save_config(config_data)  # Save it back down
     return
 
 def is_valid_dir(directory):
@@ -51,6 +51,7 @@ def main():
     args = parser.parse_args()
     if args.update_dir:
         update_movie_path(args.update_dir)
+        config_data = load_config()  # Reload config data
 
     movie_dir = config_data[0]['movie_dir']
     choose_player_and_play(movie_dir)


### PR DESCRIPTION
This closes #4 by adding in the ability to specify the  --update-dir parameter, this parameter will allow you to update the movie path without opening the config file yourself. 

Example Usage:
```py
theatre-cli --update-dir C:\Videos
```

I've added in some safeguards to this, you have to provide a valid directory path or it won't do anything. 
Since we are using argparse we get nice formatted messages for -h and help text that look like:
```
usage: theatre-cli [-h] [--update-dir PATH]

Theatre CLI

options:
  -h, --help         show this help message and exit
  --update-dir PATH  the directory to set as movie path
  ```